### PR TITLE
fix: use control instead of layer

### DIFF
--- a/Vue2LeafletLocatecontrol.vue
+++ b/Vue2LeafletLocatecontrol.vue
@@ -33,7 +33,7 @@ export default {
   },
 
   beforeDestroy() {
-    this.parentContainer.removeLayer(this);
+    this.$parent.mapObject.removeControl(this.mapObject);
   },
 
   mounted() {
@@ -42,7 +42,9 @@ export default {
     propsBinder(this, this.mapObject, props);
     this.ready = true;
     this.parentContainer = findRealParent(this.$parent);
-    this.mapObject.addTo(this.parentContainer.mapObject, !this.visible);
+    if (this.$parent._isMounted) {
+      this.$parent.mapObject.addControl(this.mapObject);
+    }
   }
 }
 </script>


### PR DESCRIPTION
Update to use "_control_" feature instead of layer, because `this.parentContainer.removeLayer(this);` not remove the component.
So if you want to render the component conditionally, he is not removed.